### PR TITLE
Bump xml-hl7-parser-service version to 1.2.0.0.4

### DIFF
--- a/xml-hl7-parser-service/build.gradle
+++ b/xml-hl7-parser-service/build.gradle
@@ -9,7 +9,7 @@ springBoot {
 }
 
 group = 'gov.cdc'
-version = '0.0.1'
+version = '1.2.0.0.4'
 
 
 repositories {


### PR DESCRIPTION
This PR updates `xml-hl7-parser-service/build.gradle` to `1.2.0.0.4`.