### PR TITLE
[CTHULHU-30] Fix formatting commit SHA post-squash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # Formatting commits to ignore in git blame
 
 # apply formatting
-a76d1fd5b4a9d9d007473fcab1d76f9ca227b97a
+64bbb5a78aff61b0a9b347f8be3f7822cebbe4c5


### PR DESCRIPTION
Updates `.git-blame-ignore-revs` to target the squashed commit after merging #118 