### PR TITLE
CTHLU-69 - copy code and config from data-extraction-service into case-notification-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build
 .env
 
 .tool-versions
+
+# Spring local application config
+application-local.yaml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This document outlines how the CDC Case Notification system operates end-to-end.
 
+## TODO: update README for service consolidation
+
 ---
 
 ## Input

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This document outlines how the CDC Case Notification system operates end-to-end.
 
-## TODO: update README for service consolidation
-
 ---
 
 ## Input
@@ -12,9 +10,8 @@ The pipeline begins with a **Debezium source connector** configured on the `ODSE
 
 - Any new data inserted into this table is detected by the connector.
 - The connector publishes the data to a **Kafka topic**.
-- This topic is consumed by the **Data Extraction** service.
 
-The **Case Notification** process depends on predefined configurations stored in the `MSOUTE..Case_Notification_Config` table.
+The **Case Notification** process depends on predefined configurations stored in the `MSOUTE..NBS_Case_Notification_Config` table.
 
 - This table contains all essential settings required for the pipeline to operate correctly.
 - It includes **PHINMS properties** that are critical for downstream processing.
@@ -32,21 +29,6 @@ The **Case Notification** process depends on predefined configurations stored in
     - For further investigation by analysts.
 
 ---
-
-## Service Requirements
-
-To function correctly, **all three services** must be available:
-
-- **Data Extraction**
-- **Case Notification**
-- **HL7 Parser**
-
----
-
-## Data Extraction
-
-- Continuously extracts and categorizes data.
-- Sends data downstream using Debezium and Kafka.
 
 ### Requirements:
 
@@ -73,7 +55,7 @@ To function correctly, **all three services** must be available:
     - `NetssTransportQOut`
 - Invalid events are ignored.
 - Faulty MMG or STD events are pushed to:
-    - `Case_Notification_DLT`
+    - `case_notification_dlt`
 
 ### API Capabilities:
 
@@ -103,17 +85,6 @@ To function correctly, **all three services** must be available:
 ---
 
 ## ⚙️ Required Environment Variables
-
-### Data Extraction
-
-| Variable              | Description              |
-|-----------------------|--------------------------|
-| `NBS_DBSERVER`        | Database URL             |
-| `NBS_DBUSER`          | Database username        |
-| `NBS_DBPASSWORD`      | Database password        |
-| `KAFKA_BOOTSTRAP_SERVER` | Kafka URL              |
-
----
 
 ### Case Notification
 
@@ -172,7 +143,6 @@ To function correctly, **all three services** must be available:
     - **Kafka** on port `9092`
     - **Kafka UI** on port `8080`
     - **Case Notification Service** on port `8093`
-    - **Data Extraction Service** on port `8090`
 
 3. To run in the background:
 

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/config/KafkaConsumerConfig.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/config/KafkaConsumerConfig.java
@@ -31,6 +31,9 @@ public class KafkaConsumerConfig {
   @Value("${spring.kafka.group-id.non-std-group-id}")
   private String nonStdGroupId;
 
+  @Value("${spring.kafka.group-id.cn-transportq-out-group-id}")
+  private String cnTransportQOutGroupId;
+
   private Map<String, Object> baseConsumerConfigs(String groupId) {
     Map<String, Object> config = new HashMap<>();
     config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -79,5 +82,11 @@ public class KafkaConsumerConfig {
   public ConcurrentKafkaListenerContainerFactory<String, String>
       kafkaListenerContainerFactoryConsumerForNonStd() {
     return createContainerFactory(nonStdGroupId);
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, String>
+      kafkaListenerContainerFactoryDebeziumConsumer() {
+    return createContainerFactory(cnTransportQOutGroupId);
   }
 }

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/config/OdseDataSourceConfig.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/config/OdseDataSourceConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
@@ -71,5 +72,10 @@ public class OdseDataSourceConfig {
   public PlatformTransactionManager odseTransactionManager(
       @Qualifier("odseEntityManagerFactory") EntityManagerFactory odseEntityManagerFactory) {
     return new JpaTransactionManager(odseEntityManagerFactory);
+  }
+
+  @Bean(name = "odseJdbcTemplate")
+  public JdbcTemplate odseJdbcTemplate(@Qualifier("odseDataSource") DataSource dataSource) {
+    return new JdbcTemplate(dataSource);
   }
 }

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
@@ -1,6 +1,7 @@
 package gov.cdc.casenotificationservice.kafka.consumer;
 
 import com.google.gson.Gson;
+import gov.cdc.casenotificationservice.exception.NonRetryableException;
 import gov.cdc.casenotificationservice.kafka.producer.CNTransportProducer;
 import gov.cdc.casenotificationservice.model.CnTransportqOutMessage;
 import gov.cdc.casenotificationservice.model.CnTransportqOutValue;
@@ -13,6 +14,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.DltStrategy;
+import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -35,6 +40,17 @@ public class CNTransportQOutConsumer {
     this.caseNotificationConfigRepository = caseNotificationConfigRepository;
   }
 
+  @RetryableTopic(
+      attempts = "${spring.kafka.retry.max-retry}",
+      autoCreateTopics = "false",
+      dltStrategy = DltStrategy.FAIL_ON_ERROR,
+      retryTopicSuffix = "${spring.kafka.retry.suffix}",
+      dltTopicSuffix = "${spring.kafka.dlt.suffix}",
+      // retry topic name, such as topic-retry-1, topic-retry-2, etc
+      topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
+      // time to wait before attempting to retry
+      backoff = @Backoff(delay = 1000, multiplier = 2.0),
+      exclude = {NonRetryableException.class})
   @KafkaListener(
       topics = "${spring.kafka.topic.cn-transportq-out-topic}",
       containerFactory = "kafkaListenerContainerFactoryDebeziumConsumer")

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
@@ -119,6 +119,9 @@ public class CNTransportQOutConsumer {
     }
   }
 
+  /**
+   * Process DLT messages through the {@link DltService}.
+   */
   @DltHandler
   public void handleDlt(
       String message,

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
@@ -6,19 +6,24 @@ import gov.cdc.casenotificationservice.model.CnTransportqOutMessage;
 import gov.cdc.casenotificationservice.model.CnTransportqOutValue;
 import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationConfigRepository;
+import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationConfig;
 import gov.cdc.casenotificationservice.service.cntransportqout.StdCheckerTransformerService;
 import gov.cdc.casenotificationservice.service.cntransportqout.UpdateService;
 import gov.cdc.casenotificationservice.service.common.ConfigurationService;
+import gov.cdc.casenotificationservice.service.common.DltService;
 import gov.cdc.casenotificationservice.service.nonstd.NonStdService;
 import gov.cdc.casenotificationservice.service.std.XmlService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.retrytopic.DltStrategy;
 import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 
@@ -39,6 +44,8 @@ public class CNTransportQOutConsumer {
 
   @Autowired private NonStdService nonStdService;
 
+  @Autowired private DltService dltService;
+
   private final CaseNotificationConfigRepository caseNotificationConfigRepository;
 
   public CNTransportQOutConsumer(
@@ -47,13 +54,15 @@ public class CNTransportQOutConsumer {
       CaseNotificationConfigRepository caseNotificationConfigRepository,
       ConfigurationService configurationService,
       XmlService xmlService,
-      NonStdService nonStdService) {
+      NonStdService nonStdService,
+      DltService dltService) {
     this.transformerService = transformerService;
     this.updateService = updateService;
     this.caseNotificationConfigRepository = caseNotificationConfigRepository;
     this.configurationService = configurationService;
     this.xmlService = xmlService;
     this.nonStdService = nonStdService;
+    this.dltService = dltService;
   }
 
   @RetryableTopic(
@@ -70,45 +79,53 @@ public class CNTransportQOutConsumer {
   @KafkaListener(
       topics = "${spring.kafka.topic.cn-transportq-out-topic}",
       containerFactory = "kafkaListenerContainerFactoryDebeziumConsumer")
-  public void handleMessage(String messages) {
-    try {
-      var config = caseNotificationConfigRepository.findNonStdConfig();
-      if (config != null && config.getConfigApplied()) {
-        logger.info("Raw message: {}", messages);
-        Gson gson = new Gson();
-        CnTransportqOutMessage message = gson.fromJson(messages, CnTransportqOutMessage.class);
+  public void handleMessage(String messages)
+      throws IgnorableException,
+          NonRetryableException,
+          NonStdProcessorServiceException,
+          StdProcessorServiceException,
+          NonStdBatchProcessorServiceException {
+    CaseNotificationConfig config = caseNotificationConfigRepository.findNonStdConfig();
+    if (config != null && config.getConfigApplied()) {
+      logger.info("Raw message: {}", messages);
+      Gson gson = new Gson();
+      CnTransportqOutMessage message = gson.fromJson(messages, CnTransportqOutMessage.class);
 
-        CnTransportqOutValue after = message.getPayload().getAfter();
-        if (after != null) {
-          MessageAfterStdChecker transformed = transformerService.transform(after);
+      CnTransportqOutValue after = message.getPayload().getAfter();
+      if (after != null) {
+        MessageAfterStdChecker transformed = transformerService.transform(after);
 
-          if (transformed != null) {
-            logger.info("Transformed message ready: {}", transformed);
+        if (transformed != null) {
+          logger.info("Transformed message ready: {}", transformed);
 
-            // Process event found in message
-            processEvent(transformed);
+          // Process event found in message
+          processEvent(transformed);
 
-            // Update database record_status_cd
-            if (transformed.isStdMessageDetected()
-                && ("NETSS_MESSAGE_ONLY".equals(transformed.getNetssMessageOnly())
-                    || "BOTH".equals(transformed.getNetssMessageOnly()))) {
-              updateService.updateRecordStatus(
-                  transformed.getCnTransportqOutUid(), "STD_PROCESSING");
-            } else {
-              updateService.updateRecordStatus(
-                  transformed.getCnTransportqOutUid(), "NON_STD_PROCESSING");
-            }
+          // Update database record_status_cd
+          if (transformed.isStdMessageDetected()
+              && ("NETSS_MESSAGE_ONLY".equals(transformed.getNetssMessageOnly())
+                  || "BOTH".equals(transformed.getNetssMessageOnly()))) {
+            updateService.updateRecordStatus(transformed.getCnTransportqOutUid(), "STD_PROCESSING");
           } else {
-            logger.info("Message skipped - did not meet the criteria");
+            updateService.updateRecordStatus(
+                transformed.getCnTransportqOutUid(), "NON_STD_PROCESSING");
           }
         } else {
-          logger.info("Change Data Capture event ignored (no 'after' state)");
+          logger.info("Message skipped - did not meet the criteria");
         }
+      } else {
+        logger.info("Change Data Capture event ignored (no 'after' state)");
       }
-
-    } catch (Exception e) {
-      logger.error("ConsumerService.handleMessage: {}", e.getMessage(), e);
     }
+  }
+
+  @DltHandler
+  public void handleDlt(
+      String message,
+      @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+      @Header(KafkaHeaders.EXCEPTION_STACKTRACE) String stacktrace) {
+    logger.info("Received DLT message: {}", message);
+    dltService.creatingDlt(message, topic, stacktrace, topic);
   }
 
   /**

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
@@ -1,0 +1,81 @@
+package gov.cdc.casenotificationservice.kafka.consumer;
+
+import com.google.gson.Gson;
+import gov.cdc.casenotificationservice.kafka.producer.CNTransportProducer;
+import gov.cdc.casenotificationservice.model.CnTransportqOutMessage;
+import gov.cdc.casenotificationservice.model.CnTransportqOutValue;
+import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
+import gov.cdc.casenotificationservice.repository.msg.CaseNotificationConfigRepository;
+import gov.cdc.casenotificationservice.service.cntransportqout.StdCheckerTransformerService;
+import gov.cdc.casenotificationservice.service.cntransportqout.UpdateService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CNTransportQOutConsumer {
+  private static final Logger logger = LoggerFactory.getLogger(CNTransportQOutConsumer.class);
+
+  @Value("${spring.kafka.topic.cn-transportq-out-topic}")
+  private String transportOutQTopic;
+
+  @Autowired private StdCheckerTransformerService transformerService;
+
+  @Autowired private CNTransportProducer producerService;
+
+  @Autowired private UpdateService updateService;
+
+  private final CaseNotificationConfigRepository caseNotificationConfigRepository;
+
+  public CNTransportQOutConsumer(
+      CaseNotificationConfigRepository caseNotificationConfigRepository) {
+    this.caseNotificationConfigRepository = caseNotificationConfigRepository;
+  }
+
+  @KafkaListener(
+      topics = "${spring.kafka.topic.cn-transportq-out-topic}",
+      containerFactory = "kafkaListenerContainerFactoryDebeziumConsumer")
+  public void handleMessage(String messages) {
+    try {
+      var config = caseNotificationConfigRepository.findNonStdConfig();
+      if (config != null && config.getConfigApplied()) {
+        logger.info("Raw message: {}", messages);
+        Gson gson = new Gson();
+        CnTransportqOutMessage message = gson.fromJson(messages, CnTransportqOutMessage.class);
+
+        CnTransportqOutValue after = message.getPayload().getAfter();
+        if (after != null) {
+          MessageAfterStdChecker transformed = transformerService.transform(after);
+
+          if (transformed != null) {
+            logger.info("Transformed message ready: {}", transformed);
+
+            // Send to downstream Kafka
+            producerService.sendMessage(transformed);
+
+            // Update database record_status_cd
+            if (transformed.isStdMessageDetected()
+                && ("NETSS_MESSAGE_ONLY".equals(transformed.getNetssMessageOnly())
+                    || "BOTH".equals(transformed.getNetssMessageOnly()))) {
+              updateService.updateRecordStatus(
+                  transformed.getCnTransportqOutUid(), "STD_PROCESSING");
+            } else {
+              updateService.updateRecordStatus(
+                  transformed.getCnTransportqOutUid(), "NON_STD_PROCESSING");
+            }
+          } else {
+            logger.info("Message skipped - did not meet the criteria");
+          }
+        } else {
+          logger.info("Change Data Capture event ignored (no 'after' state)");
+        }
+      }
+
+    } catch (Exception e) {
+      logger.error("ConsumerService.handleMessage: {}", e.getMessage(), e);
+    }
+  }
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumer.java
@@ -1,14 +1,16 @@
 package gov.cdc.casenotificationservice.kafka.consumer;
 
 import com.google.gson.Gson;
-import gov.cdc.casenotificationservice.exception.NonRetryableException;
-import gov.cdc.casenotificationservice.kafka.producer.CNTransportProducer;
+import gov.cdc.casenotificationservice.exception.*;
 import gov.cdc.casenotificationservice.model.CnTransportqOutMessage;
 import gov.cdc.casenotificationservice.model.CnTransportqOutValue;
 import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationConfigRepository;
 import gov.cdc.casenotificationservice.service.cntransportqout.StdCheckerTransformerService;
 import gov.cdc.casenotificationservice.service.cntransportqout.UpdateService;
+import gov.cdc.casenotificationservice.service.common.ConfigurationService;
+import gov.cdc.casenotificationservice.service.nonstd.NonStdService;
+import gov.cdc.casenotificationservice.service.std.XmlService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,15 +31,29 @@ public class CNTransportQOutConsumer {
 
   @Autowired private StdCheckerTransformerService transformerService;
 
-  @Autowired private CNTransportProducer producerService;
-
   @Autowired private UpdateService updateService;
+
+  @Autowired private ConfigurationService configurationService;
+
+  @Autowired private XmlService xmlService;
+
+  @Autowired private NonStdService nonStdService;
 
   private final CaseNotificationConfigRepository caseNotificationConfigRepository;
 
   public CNTransportQOutConsumer(
-      CaseNotificationConfigRepository caseNotificationConfigRepository) {
+      StdCheckerTransformerService transformerService,
+      UpdateService updateService,
+      CaseNotificationConfigRepository caseNotificationConfigRepository,
+      ConfigurationService configurationService,
+      XmlService xmlService,
+      NonStdService nonStdService) {
+    this.transformerService = transformerService;
+    this.updateService = updateService;
     this.caseNotificationConfigRepository = caseNotificationConfigRepository;
+    this.configurationService = configurationService;
+    this.xmlService = xmlService;
+    this.nonStdService = nonStdService;
   }
 
   @RetryableTopic(
@@ -69,8 +85,8 @@ public class CNTransportQOutConsumer {
           if (transformed != null) {
             logger.info("Transformed message ready: {}", transformed);
 
-            // Send to downstream Kafka
-            producerService.sendMessage(transformed);
+            // Process event found in message
+            processEvent(transformed);
 
             // Update database record_status_cd
             if (transformed.isStdMessageDetected()
@@ -93,5 +109,32 @@ public class CNTransportQOutConsumer {
     } catch (Exception e) {
       logger.error("ConsumerService.handleMessage: {}", e.getMessage(), e);
     }
+  }
+
+  /**
+   * Call the requisite service for the given message. Service call is based upon whether message is
+   * STD or NON-STD.
+   */
+  void processEvent(MessageAfterStdChecker messageAfterStdChecker)
+      throws IgnorableException,
+          NonStdProcessorServiceException,
+          NonStdBatchProcessorServiceException,
+          NonRetryableException,
+          StdProcessorServiceException {
+    String messageType = messageAfterStdChecker.isStdMessageDetected() ? "std" : "non-std";
+    logger.info("Received {} message", messageType);
+    if (!configurationService.checkConfigurationAvailable()) {
+      logger.warn("configuration not available, unable to process {} message", messageType);
+      return;
+    }
+
+    if (messageAfterStdChecker.isStdMessageDetected()) {
+      xmlService.mappingXmlStringToObject(messageAfterStdChecker);
+    } else {
+      nonStdService.nonStdProcessor(
+          messageAfterStdChecker, configurationService.checkHl7ValidationApplied());
+    }
+
+    logger.info("Completed {} message", messageType);
   }
 }

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/producer/CNTransportProducer.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/kafka/producer/CNTransportProducer.java
@@ -1,0 +1,45 @@
+package gov.cdc.casenotificationservice.kafka.producer;
+
+import com.google.gson.Gson;
+import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class CNTransportProducer {
+
+  private final KafkaTemplate<String, String> kafkaTemplate;
+  private final Gson gson;
+
+  @Value("${spring.kafka.topic.std-topic}")
+  private String stdTopic;
+
+  @Value("${spring.kafka.topic.non-std-topic}")
+  private String nonStdTopic;
+
+  public CNTransportProducer(KafkaTemplate<String, String> kafkaTemplate, Gson gson) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.gson = gson;
+  }
+
+  public void sendMessage(MessageAfterStdChecker transformedMessage) {
+    try {
+      String payload = gson.toJson(transformedMessage);
+
+      if (transformedMessage.isStdMessageDetected()) {
+        kafkaTemplate.send(stdTopic, payload);
+        log.info("Sent transformed message to std topic {}: {}", stdTopic, payload);
+        kafkaTemplate.send(nonStdTopic, payload);
+        log.info("Sent transformed message to non-std topic {}: {}", nonStdTopic, payload);
+      } else {
+        kafkaTemplate.send(nonStdTopic, payload);
+        log.info("Sent transformed message to non-std topic {}: {}", nonStdTopic, payload);
+      }
+    } catch (Exception e) {
+      log.error("Failed to send message to Kafka: {}", e.getMessage(), e);
+    }
+  }
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/CnTransportqOutMessage.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/CnTransportqOutMessage.java
@@ -1,0 +1,10 @@
+package gov.cdc.casenotificationservice.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CnTransportqOutMessage {
+  public EnvelopePayload payload;
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/CnTransportqOutValue.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/CnTransportqOutValue.java
@@ -1,0 +1,24 @@
+package gov.cdc.casenotificationservice.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CnTransportqOutValue {
+  public long cn_transportq_out_uid;
+  public String add_reason_cd;
+  public Long add_time;
+  public Long add_user_id;
+  public String last_chg_reason_cd;
+  public Long last_chg_time;
+  public Long last_chg_user_id;
+  public String message_payload;
+  public long notification_uid;
+  public String notification_local_id;
+  public String public_health_case_local_id;
+  public String report_status_cd;
+  public String record_status_cd;
+  public Long record_status_time;
+  public Short version_ctrl_nbr;
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/EnvelopePayload.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/EnvelopePayload.java
@@ -1,0 +1,17 @@
+package gov.cdc.casenotificationservice.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EnvelopePayload {
+  public CnTransportqOutValue before;
+  public CnTransportqOutValue after;
+  public SourceConnectorInfo source;
+  public TransactionBlock transaction;
+  public String op;
+  public Long ts_ms;
+  public Long ts_us;
+  public Long ts_ns;
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/SourceConnectorInfo.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/SourceConnectorInfo.java
@@ -1,0 +1,23 @@
+package gov.cdc.casenotificationservice.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SourceConnectorInfo {
+  public String version;
+  public String connector;
+  public String name;
+  public long ts_ms;
+  public String snapshot;
+  public String db;
+  public String sequence;
+  public Long ts_us;
+  public Long ts_ns;
+  public String schema;
+  public String table;
+  public String change_lsn;
+  public String commit_lsn;
+  public Long event_serial_no;
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/TransactionBlock.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/model/TransactionBlock.java
@@ -1,0 +1,12 @@
+package gov.cdc.casenotificationservice.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TransactionBlock {
+  public String id;
+  public long total_order;
+  public long data_collection_order;
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/repository/msg/CaseNotificationConfigRepository.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/repository/msg/CaseNotificationConfigRepository.java
@@ -14,6 +14,12 @@ public interface CaseNotificationConfigRepository
       value =
           "SELECT TOP 1 * FROM NBS_Case_Notification_Config WHERE config_applied = 1 AND config_name = 'NON_STD_CASE_NOTIFICATION';",
       nativeQuery = true)
+  CaseNotificationConfig findAppliedNonStdConfig();
+
+  @Query(
+      value =
+          "SELECT TOP 1 * FROM NBS_Case_Notification_Config WHERE config_name = 'NON_STD_CASE_NOTIFICATION';",
+      nativeQuery = true)
   CaseNotificationConfig findNonStdConfig();
 
   @Query(

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/repository/odse/CNTransportQOutRepository.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/repository/odse/CNTransportQOutRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CNTransportqOutRepository extends JpaRepository<CNTransportqOut, Long> {
+public interface CNTransportQOutRepository extends JpaRepository<CNTransportqOut, Long> {
   @Query(
       value = "SELECT TOP 1 * FROM dbo.CN_transportq_out WHERE record_status_cd = :recordStatusCd",
       nativeQuery = true)

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/repository/odse/CNTransportqOutRepository.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/repository/odse/CNTransportqOutRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CNTraportqOutRepository extends JpaRepository<CNTransportqOut, Long> {
+public interface CNTransportqOutRepository extends JpaRepository<CNTransportqOut, Long> {
   @Query(
       value = "SELECT TOP 1 * FROM dbo.CN_transportq_out WHERE record_status_cd = :recordStatusCd",
       nativeQuery = true)

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/cntransportqout/StdCheckerTransformerService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/cntransportqout/StdCheckerTransformerService.java
@@ -1,0 +1,67 @@
+package gov.cdc.casenotificationservice.service.cntransportqout;
+
+import gov.cdc.casenotificationservice.model.CnTransportqOutValue;
+import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class StdCheckerTransformerService {
+  @Value("${app.transformer.netss-message-only}")
+  private String netssMessageOnlyConfig;
+
+  public MessageAfterStdChecker transform(CnTransportqOutValue value) {
+    if (value == null) {
+      log.warn("TransformerService: Received null payload.");
+      return null;
+    }
+
+    String recordStatusCd = value.getRecord_status_cd();
+    if (!"UNPROCESSED".equalsIgnoreCase(recordStatusCd)) {
+      log.info("Skipping message: record_status_cd is not UNPROCESSED or missing.");
+      return null;
+    }
+
+    String body = value.getMessage_payload();
+    if (body == null) {
+      log.warn("TransformerService: message_payload is null.");
+      return null;
+    }
+
+    // Replace problematic characters
+    String cleanedPayload = body.replaceAll("'", "&apos;").replaceAll("â€™", "&apos;");
+
+    // Check if body contains <stringData>STD_MMG_V1.0</stringData>
+    boolean containsTrigger = cleanedPayload.contains("<stringData>STD_MMG_V1.0</stringData>");
+    String netssStatus = "queued";
+
+    if (containsTrigger) {
+      switch (netssMessageOnlyConfig) {
+        case "NETSS_MESSAGE_ONLY":
+          netssStatus = "NETSS_MESSAGE_ONLY";
+          break;
+        case "BOTH":
+          netssStatus = "BOTH";
+          break;
+        default:
+          netssStatus = "queued";
+      }
+    }
+
+    MessageAfterStdChecker msg = new MessageAfterStdChecker();
+
+    msg.setCnTransportqOutUid(value.getCn_transportq_out_uid());
+    // n.b.: this was commented out previous to being consolidated into case-notification-service
+    //  msg.setMessagePayload(cleanedPayload);
+    msg.setNotificationLocalId(value.getNotification_local_id());
+    msg.setPublicHealthCaseLocalId(value.getPublic_health_case_local_id());
+    msg.setReportStatusCd(value.getReport_status_cd());
+    msg.setRecordStatusCd(value.getRecord_status_cd());
+    msg.setNetssMessageOnly(netssStatus);
+    msg.setStdMessageDetected(containsTrigger);
+
+    return msg;
+  }
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/cntransportqout/UpdateService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/cntransportqout/UpdateService.java
@@ -1,0 +1,35 @@
+package gov.cdc.casenotificationservice.service.cntransportqout;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class UpdateService {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public UpdateService(@Qualifier("odseJdbcTemplate") JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public void updateRecordStatus(long cnTransportqOutUid, String newStatus) {
+    String sql =
+        "UPDATE CN_transportq_out "
+            + "SET record_status_cd = ?, record_status_time = GETDATE() "
+            + "WHERE cn_transportq_out_uid = ?";
+
+    int rows = jdbcTemplate.update(sql, newStatus, cnTransportqOutUid);
+
+    if (rows > 0) {
+      log.info(
+          "Successfully updated record_status_cd to '{}' for cn_transportq_out_uid={}",
+          newStatus,
+          cnTransportqOutUid);
+    } else {
+      log.warn("No record updated for cn_transportq_out_uid={}", cnTransportqOutUid);
+    }
+  }
+}

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/ConfigurationService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/ConfigurationService.java
@@ -45,7 +45,7 @@ public class ConfigurationService implements IConfigurationService {
   }
 
   public CaseNotificationConfig getAppliedCaseNotificationConfig() {
-    return caseNotificationConfigRepository.findNonStdConfig();
+    return caseNotificationConfigRepository.findAppliedNonStdConfig();
   }
 
   public CaseNotificationConfig saveConfig(CaseNotificationConfigDto configDto) {

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/DltService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/DltService.java
@@ -9,7 +9,7 @@ import gov.cdc.casenotificationservice.model.ApiDltResponseModel;
 import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationDltRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationDlt;
-import gov.cdc.casenotificationservice.repository.odse.CNTraportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
 import gov.cdc.casenotificationservice.service.common.interfaces.IDltService;
 import java.sql.Timestamp;
 import java.util.UUID;
@@ -31,15 +31,15 @@ public class DltService implements IDltService {
   private String stdTopic;
 
   private final CaseNotificationDltRepository caseNotificationDltRepository;
-  private final CNTraportqOutRepository cnTraportqOutRepository;
+  private final CNTransportqOutRepository cnTransportqOutRepository;
   private final CaseNotificationProducer caseNotificationProducer;
 
   public DltService(
       CaseNotificationDltRepository caseNotificationDltRepository,
-      CNTraportqOutRepository cnTraportqOutRepository,
+      CNTransportqOutRepository cnTransportqOutRepository,
       CaseNotificationProducer caseNotificationProducer) {
     this.caseNotificationDltRepository = caseNotificationDltRepository;
-    this.cnTraportqOutRepository = cnTraportqOutRepository;
+    this.cnTransportqOutRepository = cnTransportqOutRepository;
     this.caseNotificationProducer = caseNotificationProducer;
   }
 
@@ -73,7 +73,7 @@ public class DltService implements IDltService {
 
     var cnTransportqOut =
         (data != null && data.getCnTransportqOutUid() != null)
-            ? cnTraportqOutRepository.findTopByRecordUid(data.getCnTransportqOutUid())
+            ? cnTransportqOutRepository.findTopByRecordUid(data.getCnTransportqOutUid())
             : null;
 
     CaseNotificationDlt caseNotificationDlt = new CaseNotificationDlt();
@@ -93,7 +93,7 @@ public class DltService implements IDltService {
     caseNotificationDltRepository.save(caseNotificationDlt);
 
     if (data != null && data.getCnTransportqOutUid() != null) {
-      cnTraportqOutRepository.updateStatus(data.getCnTransportqOutUid(), status);
+      cnTransportqOutRepository.updateStatus(data.getCnTransportqOutUid(), status);
     }
   }
 
@@ -129,9 +129,9 @@ public class DltService implements IDltService {
     caseNotificationDltRepository.save(caseNotificationDlt);
 
     var cnTransportqOut =
-        cnTraportqOutRepository.findTopByRecordUid(dltResult.get().getCnTranportqOutUid());
+        cnTransportqOutRepository.findTopByRecordUid(dltResult.get().getCnTranportqOutUid());
     cnTransportqOut.setMessagePayload(payload); // UPDATE NEW PAYLOAD TO CN TRANSPORT
-    cnTraportqOutRepository.save(cnTransportqOut);
+    cnTransportqOutRepository.save(cnTransportqOut);
 
     String topic;
     if (caseNotificationDlt.getSource().equalsIgnoreCase(nonStdTopic)) {

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/DltService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/DltService.java
@@ -59,18 +59,18 @@ public class DltService implements IDltService {
     var gson = new Gson();
     CnTransportqOutMessage data = gson.fromJson(message, CnTransportqOutMessage.class);
 
-    // ensure proper data shape
+    // ensure proper data shape for message
     if (data == null || data.getPayload() == null || data.getPayload().getAfter() == null) {
       log.error("Invalid data found in message: {}", message);
       throw new RuntimeException("Invalid data found in message: " + message);
     }
 
-    // get the existing entry in odse.cn_transportq_out table
+    // get the existing entry in `odse.cn_transportq_out` table
     CNTransportqOut cnTransportqOut =
         cnTransportqOutRepository.findTopByRecordUid(
             data.getPayload().getAfter().getCn_transportq_out_uid());
 
-    // create a DLT entry
+    // create a CaseNotificationDlt entry
     CaseNotificationDlt cnDlt = new CaseNotificationDlt();
     cnDlt.setCnTranportqOutUid(data.getPayload().getAfter().getCn_transportq_out_uid());
     cnDlt.setOriginalPayload(
@@ -80,7 +80,7 @@ public class DltService implements IDltService {
     cnDlt.setCreatedOn(getCurrentTimeStamp(tz));
     cnDlt.setUpdatedOn(getCurrentTimeStamp(tz));
 
-    // save DLT entry and update status on the odse.cn_transportq_out entry
+    // save CaseNotificationDlt entry and update status on the odse.cn_transportq_out entry
     caseNotificationDltRepository.save(cnDlt);
     cnTransportqOutRepository.updateStatus(
         data.getPayload().getAfter().getCn_transportq_out_uid(), "PROCESSING_ERROR");

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/DltService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/DltService.java
@@ -9,7 +9,7 @@ import gov.cdc.casenotificationservice.model.ApiDltResponseModel;
 import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationDltRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationDlt;
-import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
 import gov.cdc.casenotificationservice.service.common.interfaces.IDltService;
 import java.sql.Timestamp;
 import java.util.UUID;
@@ -31,12 +31,12 @@ public class DltService implements IDltService {
   private String stdTopic;
 
   private final CaseNotificationDltRepository caseNotificationDltRepository;
-  private final CNTransportqOutRepository cnTransportqOutRepository;
+  private final CNTransportQOutRepository cnTransportqOutRepository;
   private final CaseNotificationProducer caseNotificationProducer;
 
   public DltService(
       CaseNotificationDltRepository caseNotificationDltRepository,
-      CNTransportqOutRepository cnTransportqOutRepository,
+      CNTransportQOutRepository cnTransportqOutRepository,
       CaseNotificationProducer caseNotificationProducer) {
     this.caseNotificationDltRepository = caseNotificationDltRepository;
     this.cnTransportqOutRepository = cnTransportqOutRepository;

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/DltService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/DltService.java
@@ -6,13 +6,15 @@ import com.google.gson.Gson;
 import gov.cdc.casenotificationservice.exception.DltServiceException;
 import gov.cdc.casenotificationservice.kafka.producer.CaseNotificationProducer;
 import gov.cdc.casenotificationservice.model.ApiDltResponseModel;
-import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
+import gov.cdc.casenotificationservice.model.CnTransportqOutMessage;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationDltRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationDlt;
 import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import gov.cdc.casenotificationservice.service.common.interfaces.IDltService;
 import java.sql.Timestamp;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -20,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class DltService implements IDltService {
   @Value("${service.timezone}")
   private String tz = "UTC";
@@ -48,53 +51,39 @@ public class DltService implements IDltService {
     return res.orElse(null);
   }
 
+  /**
+   * Save given message to the `NBS_MSGOUTE.case_notification_dlt` table and update its status in
+   * `NBS_ODSE.CN_transportq_out`.
+   */
   public void creatingDlt(String message, String topic, String stacktrace, String origin) {
     var gson = new Gson();
-    String status;
-    MessageAfterStdChecker data = null;
-    try {
-      if (message == null || message.trim().isEmpty()) {
-        status = "INVALID_ERR";
-      } else {
-        data = gson.fromJson(message, MessageAfterStdChecker.class);
-        if (data == null || data.getCnTransportqOutUid() == null) {
-          status = "INVALID_ERR";
-        } else if (Boolean.TRUE.equals(data.isStdMessageDetected())) {
-          status = "STD_ERR";
-        } else if (Boolean.FALSE.equals(data.isStdMessageDetected())) {
-          status = "NONSTD_ERR";
-        } else {
-          status = "UNKNOWN_ERR";
-        }
-      }
-    } catch (Exception e) {
-      status = "INVALID_ERR";
+    CnTransportqOutMessage data = gson.fromJson(message, CnTransportqOutMessage.class);
+
+    // ensure proper data shape
+    if (data == null || data.getPayload() == null || data.getPayload().getAfter() == null) {
+      log.error("Invalid data found in message: {}", message);
+      throw new RuntimeException("Invalid data found in message: " + message);
     }
 
-    var cnTransportqOut =
-        (data != null && data.getCnTransportqOutUid() != null)
-            ? cnTransportqOutRepository.findTopByRecordUid(data.getCnTransportqOutUid())
-            : null;
+    // get the existing entry in odse.cn_transportq_out table
+    CNTransportqOut cnTransportqOut =
+        cnTransportqOutRepository.findTopByRecordUid(
+            data.getPayload().getAfter().getCn_transportq_out_uid());
 
-    CaseNotificationDlt caseNotificationDlt = new CaseNotificationDlt();
-    if (data != null) {
-      caseNotificationDlt.setCnTranportqOutUid(data.getCnTransportqOutUid());
-    }
-    if (cnTransportqOut != null) {
-      caseNotificationDlt.setOriginalPayload(cnTransportqOut.getMessagePayload());
-    } else {
-      caseNotificationDlt.setOriginalPayload(message);
-    }
-    caseNotificationDlt.setSource(origin);
-    caseNotificationDlt.setErrorStackTrace(stacktrace);
-    caseNotificationDlt.setCreatedOn(getCurrentTimeStamp(tz));
-    caseNotificationDlt.setUpdatedOn(getCurrentTimeStamp(tz));
+    // create a DLT entry
+    CaseNotificationDlt cnDlt = new CaseNotificationDlt();
+    cnDlt.setCnTranportqOutUid(data.getPayload().getAfter().getCn_transportq_out_uid());
+    cnDlt.setOriginalPayload(
+        cnTransportqOut == null ? message : cnTransportqOut.getMessagePayload());
+    cnDlt.setSource(origin);
+    cnDlt.setErrorStackTrace(stacktrace);
+    cnDlt.setCreatedOn(getCurrentTimeStamp(tz));
+    cnDlt.setUpdatedOn(getCurrentTimeStamp(tz));
 
-    caseNotificationDltRepository.save(caseNotificationDlt);
-
-    if (data != null && data.getCnTransportqOutUid() != null) {
-      cnTransportqOutRepository.updateStatus(data.getCnTransportqOutUid(), status);
-    }
+    // save DLT entry and update status on the odse.cn_transportq_out entry
+    caseNotificationDltRepository.save(cnDlt);
+    cnTransportqOutRepository.updateStatus(
+        data.getPayload().getAfter().getCn_transportq_out_uid(), "PROCESSING_ERROR");
   }
 
   public Page<CaseNotificationDlt> getDltsBetweenWithPagination(

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/StatusService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/StatusService.java
@@ -8,24 +8,24 @@ import gov.cdc.casenotificationservice.model.view_model.TransportOutVM;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationDltRepository;
 import gov.cdc.casenotificationservice.repository.msg.NetssTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.TransportQOutRepository;
-import gov.cdc.casenotificationservice.repository.odse.CNTraportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
 import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import gov.cdc.casenotificationservice.service.common.interfaces.IStatusService;
 import org.springframework.stereotype.Service;
 
 @Service
 public class StatusService implements IStatusService {
-  private final CNTraportqOutRepository cnTraportqOutRepository;
+  private final CNTransportqOutRepository cnTransportqOutRepository;
   private final TransportQOutRepository transportQOutRepository;
   private final NetssTransportQOutRepository netssTransportQOutRepository;
   private final CaseNotificationDltRepository caseNotificationDltRepository;
 
   public StatusService(
-      CNTraportqOutRepository cnTraportqOutRepository,
+      CNTransportqOutRepository cnTransportqOutRepository,
       TransportQOutRepository transportQOutRepository,
       NetssTransportQOutRepository netssTransportQOutRepository,
       CaseNotificationDltRepository caseNotificationDltRepository) {
-    this.cnTraportqOutRepository = cnTraportqOutRepository;
+    this.cnTransportqOutRepository = cnTransportqOutRepository;
     this.transportQOutRepository = transportQOutRepository;
     this.netssTransportQOutRepository = netssTransportQOutRepository;
     this.caseNotificationDltRepository = caseNotificationDltRepository;
@@ -34,7 +34,7 @@ public class StatusService implements IStatusService {
   public ApiStatusResponseModel getProcessedStatus(Long cnTraportqOutId) {
     ApiStatusResponseModel aStatusResponseModel = new ApiStatusResponseModel();
 
-    var cnTransportOpt = cnTraportqOutRepository.findById(cnTraportqOutId);
+    var cnTransportOpt = cnTransportqOutRepository.findById(cnTraportqOutId);
     if (cnTransportOpt.isPresent()) {
       CNTransportqOut cnTraportqOut = cnTransportOpt.get();
 

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/StatusService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/common/StatusService.java
@@ -8,20 +8,20 @@ import gov.cdc.casenotificationservice.model.view_model.TransportOutVM;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationDltRepository;
 import gov.cdc.casenotificationservice.repository.msg.NetssTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.TransportQOutRepository;
-import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import gov.cdc.casenotificationservice.service.common.interfaces.IStatusService;
 import org.springframework.stereotype.Service;
 
 @Service
 public class StatusService implements IStatusService {
-  private final CNTransportqOutRepository cnTransportqOutRepository;
+  private final CNTransportQOutRepository cnTransportqOutRepository;
   private final TransportQOutRepository transportQOutRepository;
   private final NetssTransportQOutRepository netssTransportQOutRepository;
   private final CaseNotificationDltRepository caseNotificationDltRepository;
 
   public StatusService(
-      CNTransportqOutRepository cnTransportqOutRepository,
+      CNTransportQOutRepository cnTransportqOutRepository,
       TransportQOutRepository transportQOutRepository,
       NetssTransportQOutRepository netssTransportQOutRepository,
       CaseNotificationDltRepository caseNotificationDltRepository) {

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/nonstd/NonStdService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/nonstd/NonStdService.java
@@ -7,7 +7,7 @@ import gov.cdc.casenotificationservice.repository.msg.CaseNotificationConfigRepo
 import gov.cdc.casenotificationservice.repository.msg.TransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationConfig;
 import gov.cdc.casenotificationservice.repository.msg.model.TransportQOut;
-import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.INonStdBatchService;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.INonStdService;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.IPHINMSService;
@@ -28,7 +28,7 @@ public class NonStdService implements INonStdService {
   private final IPHINMSService phinmsService;
   private final INonStdBatchService batchService;
   private final TransportQOutRepository transportQOutRepository;
-  private final CNTransportqOutRepository cnTransportqOutRepository;
+  private final CNTransportQOutRepository cnTransportqOutRepository;
   private final CaseNotificationConfigRepository caseNotificationConfigRepository;
   private final Hl7MessageBuilder hl7MessageBuilder;
 
@@ -36,7 +36,7 @@ public class NonStdService implements INonStdService {
       IPHINMSService phinmsService,
       INonStdBatchService batchService,
       TransportQOutRepository transportQOutRepository,
-      CNTransportqOutRepository cnTransportqOutRepository,
+      CNTransportQOutRepository cnTransportqOutRepository,
       CaseNotificationConfigRepository caseNotificationConfigRepository,
       Hl7MessageBuilder hl7MessageBuilder) {
     this.phinmsService = phinmsService;

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/nonstd/NonStdService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/nonstd/NonStdService.java
@@ -7,7 +7,7 @@ import gov.cdc.casenotificationservice.repository.msg.CaseNotificationConfigRepo
 import gov.cdc.casenotificationservice.repository.msg.TransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationConfig;
 import gov.cdc.casenotificationservice.repository.msg.model.TransportQOut;
-import gov.cdc.casenotificationservice.repository.odse.CNTraportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.INonStdBatchService;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.INonStdService;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.IPHINMSService;
@@ -28,7 +28,7 @@ public class NonStdService implements INonStdService {
   private final IPHINMSService phinmsService;
   private final INonStdBatchService batchService;
   private final TransportQOutRepository transportQOutRepository;
-  private final CNTraportqOutRepository cnTraportqOutRepository;
+  private final CNTransportqOutRepository cnTransportqOutRepository;
   private final CaseNotificationConfigRepository caseNotificationConfigRepository;
   private final Hl7MessageBuilder hl7MessageBuilder;
 
@@ -36,13 +36,13 @@ public class NonStdService implements INonStdService {
       IPHINMSService phinmsService,
       INonStdBatchService batchService,
       TransportQOutRepository transportQOutRepository,
-      CNTraportqOutRepository cnTraportqOutRepository,
+      CNTransportqOutRepository cnTransportqOutRepository,
       CaseNotificationConfigRepository caseNotificationConfigRepository,
       Hl7MessageBuilder hl7MessageBuilder) {
     this.phinmsService = phinmsService;
     this.batchService = batchService;
     this.transportQOutRepository = transportQOutRepository;
-    this.cnTraportqOutRepository = cnTraportqOutRepository;
+    this.cnTransportqOutRepository = cnTransportqOutRepository;
     this.caseNotificationConfigRepository = caseNotificationConfigRepository;
     this.hl7MessageBuilder = hl7MessageBuilder;
   }
@@ -53,9 +53,9 @@ public class NonStdService implements INonStdService {
           NonStdProcessorServiceException,
           NonStdBatchProcessorServiceException {
     PHINMSProperties phinmsProperties = new PHINMSProperties();
-    CaseNotificationConfig stdConfig = caseNotificationConfigRepository.findNonStdConfig();
+    CaseNotificationConfig stdConfig = caseNotificationConfigRepository.findAppliedNonStdConfig();
     var cnTransport =
-        cnTraportqOutRepository.findTopByRecordUid(messageAfterStdChecker.getCnTransportqOutUid());
+        cnTransportqOutRepository.findTopByRecordUid(messageAfterStdChecker.getCnTransportqOutUid());
 
     try {
       var payload =
@@ -110,7 +110,7 @@ public class NonStdService implements INonStdService {
     transportQOutRepository.save(transportQOut);
 
     try {
-      cnTraportqOutRepository.updateStatusToQueued(
+      cnTransportqOutRepository.updateStatusToQueued(
           PHINMSProperties.getCnTransportUid()); // "WHERE IS THIS ID COME FROM"
     } catch (Exception e) {
       throw new NonRetryableException(e.getMessage(), e);

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/nonstd/NonStdService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/nonstd/NonStdService.java
@@ -55,7 +55,8 @@ public class NonStdService implements INonStdService {
     PHINMSProperties phinmsProperties = new PHINMSProperties();
     CaseNotificationConfig stdConfig = caseNotificationConfigRepository.findAppliedNonStdConfig();
     var cnTransport =
-        cnTransportqOutRepository.findTopByRecordUid(messageAfterStdChecker.getCnTransportqOutUid());
+        cnTransportqOutRepository.findTopByRecordUid(
+            messageAfterStdChecker.getCnTransportqOutUid());
 
     try {
       var payload =

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/std/XmlService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/std/XmlService.java
@@ -11,7 +11,7 @@ import gov.cdc.casenotificationservice.model.NetssPersistModel;
 import gov.cdc.casenotificationservice.model.generated.jaxb.NBSNNDIntermediaryMessage;
 import gov.cdc.casenotificationservice.repository.msg.NetssTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.NetssTransportQOut;
-import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
 import gov.cdc.casenotificationservice.service.std.interfaces.IStdMapperService;
 import gov.cdc.casenotificationservice.service.std.interfaces.IXmlService;
 import jakarta.xml.bind.JAXBContext;
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class XmlService implements IXmlService {
 
-  private final CNTransportqOutRepository cnTransportqOutRepository;
+  private final CNTransportQOutRepository cnTransportqOutRepository;
   private final IStdMapperService stdMapperService;
   private final NetssTransportQOutRepository netssTransportQOutRepository;
 
@@ -31,7 +31,7 @@ public class XmlService implements IXmlService {
   private String tz = "UTC";
 
   public XmlService(
-      CNTransportqOutRepository cnTransportqOutRepository,
+      CNTransportQOutRepository cnTransportqOutRepository,
       IStdMapperService stdMapperService,
       NetssTransportQOutRepository netssTransportQOutRepository) {
     this.cnTransportqOutRepository = cnTransportqOutRepository;

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/std/XmlService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/std/XmlService.java
@@ -11,7 +11,7 @@ import gov.cdc.casenotificationservice.model.NetssPersistModel;
 import gov.cdc.casenotificationservice.model.generated.jaxb.NBSNNDIntermediaryMessage;
 import gov.cdc.casenotificationservice.repository.msg.NetssTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.NetssTransportQOut;
-import gov.cdc.casenotificationservice.repository.odse.CNTraportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
 import gov.cdc.casenotificationservice.service.std.interfaces.IStdMapperService;
 import gov.cdc.casenotificationservice.service.std.interfaces.IXmlService;
 import jakarta.xml.bind.JAXBContext;
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class XmlService implements IXmlService {
 
-  private final CNTraportqOutRepository cnTraportqOutRepository;
+  private final CNTransportqOutRepository cnTransportqOutRepository;
   private final IStdMapperService stdMapperService;
   private final NetssTransportQOutRepository netssTransportQOutRepository;
 
@@ -31,10 +31,10 @@ public class XmlService implements IXmlService {
   private String tz = "UTC";
 
   public XmlService(
-      CNTraportqOutRepository cnTraportqOutRepository,
+      CNTransportqOutRepository cnTransportqOutRepository,
       IStdMapperService stdMapperService,
       NetssTransportQOutRepository netssTransportQOutRepository) {
-    this.cnTraportqOutRepository = cnTraportqOutRepository;
+    this.cnTransportqOutRepository = cnTransportqOutRepository;
     this.stdMapperService = stdMapperService;
     this.netssTransportQOutRepository = netssTransportQOutRepository;
   }
@@ -43,7 +43,7 @@ public class XmlService implements IXmlService {
   public void mappingXmlStringToObject(MessageAfterStdChecker messageAfterStdChecker)
       throws StdProcessorServiceException, NonRetryableException {
     var cnTransportqOut =
-        cnTraportqOutRepository.findTopByRecordUid(messageAfterStdChecker.getCnTransportqOutUid());
+        cnTransportqOutRepository.findTopByRecordUid(messageAfterStdChecker.getCnTransportqOutUid());
     String netssSummary;
     NetssPersistModel netssPersistModel = new NetssPersistModel();
 

--- a/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/std/XmlService.java
+++ b/case-notification-service/src/main/java/gov/cdc/casenotificationservice/service/std/XmlService.java
@@ -43,7 +43,8 @@ public class XmlService implements IXmlService {
   public void mappingXmlStringToObject(MessageAfterStdChecker messageAfterStdChecker)
       throws StdProcessorServiceException, NonRetryableException {
     var cnTransportqOut =
-        cnTransportqOutRepository.findTopByRecordUid(messageAfterStdChecker.getCnTransportqOutUid());
+        cnTransportqOutRepository.findTopByRecordUid(
+            messageAfterStdChecker.getCnTransportqOutUid());
     String netssSummary;
     NetssPersistModel netssPersistModel = new NetssPersistModel();
 

--- a/case-notification-service/src/main/resources/application.yaml
+++ b/case-notification-service/src/main/resources/application.yaml
@@ -60,9 +60,11 @@ spring:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVER:localhost:9092}
     thread: ${KAFKA_THREAD:1}
     group-id:
+      cn-transportq-out-group-id: cn-transportq-out
       std-group-id: std-processor-group
       non-std-group-id: non-std-processor-group
     topic:
+      cn-transportq-out-topic: nbs_CN_transportq_out
       std-topic: cn_transport_std_message
       non-std-topic: cn_transport_non_std_message
     dlt:
@@ -70,6 +72,10 @@ spring:
     retry:
       max-retry: 2
       suffix: -retry
+
+app:
+  transformer:
+    netss-message-only: NETSS_MESSAGE_ONLY
 
 auth:
   token-uri: ${spring.security.oauth2.resourceserver.jwt.issuer-uri}/protocol/openid-connect/token

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumerTests.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumerTests.java
@@ -46,7 +46,12 @@ public class CNTransportQOutConsumerTests {
   }
 
   @Test
-  public void handleMessage_stdMessage() {
+  public void handleMessage_stdMessage()
+      throws IgnorableException,
+          NonRetryableException,
+          NonStdProcessorServiceException,
+          StdProcessorServiceException,
+          NonStdBatchProcessorServiceException {
     CaseNotificationConfig config = new CaseNotificationConfig();
     config.setConfigApplied(true);
     when(caseNotificationConfigRepositoryMock.findNonStdConfig()).thenReturn(config);
@@ -69,7 +74,12 @@ public class CNTransportQOutConsumerTests {
   }
 
   @Test
-  public void handleMessage_nonStdMessage() {
+  public void handleMessage_nonStdMessage()
+      throws IgnorableException,
+          NonRetryableException,
+          NonStdProcessorServiceException,
+          StdProcessorServiceException,
+          NonStdBatchProcessorServiceException {
     CaseNotificationConfig config = new CaseNotificationConfig();
     config.setConfigApplied(true);
     when(caseNotificationConfigRepositoryMock.findNonStdConfig()).thenReturn(config);

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumerTests.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/kafka/consumer/CNTransportQOutConsumerTests.java
@@ -1,0 +1,131 @@
+package gov.cdc.casenotificationservice.kafka.consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.google.gson.Gson;
+import gov.cdc.casenotificationservice.exception.*;
+import gov.cdc.casenotificationservice.model.CnTransportqOutMessage;
+import gov.cdc.casenotificationservice.model.CnTransportqOutValue;
+import gov.cdc.casenotificationservice.model.EnvelopePayload;
+import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
+import gov.cdc.casenotificationservice.repository.msg.CaseNotificationConfigRepository;
+import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationConfig;
+import gov.cdc.casenotificationservice.service.cntransportqout.StdCheckerTransformerService;
+import gov.cdc.casenotificationservice.service.cntransportqout.UpdateService;
+import gov.cdc.casenotificationservice.service.common.ConfigurationService;
+import gov.cdc.casenotificationservice.service.nonstd.NonStdService;
+import gov.cdc.casenotificationservice.service.std.XmlService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CNTransportQOutConsumerTests {
+
+  @Mock private StdCheckerTransformerService transformerServiceMock;
+  @Mock private UpdateService updateServiceMock;
+  @Mock private CaseNotificationConfigRepository caseNotificationConfigRepositoryMock;
+  @Mock private ConfigurationService configurationServiceMock;
+  @Mock private XmlService xmlServiceMock;
+  @Mock private NonStdService nonStdServiceMock;
+  @InjectMocks private CNTransportQOutConsumer consumer;
+
+  private AutoCloseable mocksAutoClosable;
+
+  @BeforeEach
+  void beforeEach() {
+    mocksAutoClosable = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  void afterEach() throws Exception {
+    mocksAutoClosable.close();
+  }
+
+  @Test
+  public void handleMessage_stdMessage() {
+    CaseNotificationConfig config = new CaseNotificationConfig();
+    config.setConfigApplied(true);
+    when(caseNotificationConfigRepositoryMock.findNonStdConfig()).thenReturn(config);
+
+    MessageAfterStdChecker messageAfterStdChecker = new MessageAfterStdChecker();
+    messageAfterStdChecker.setStdMessageDetected(true);
+    messageAfterStdChecker.setNetssMessageOnly("BOTH");
+    messageAfterStdChecker.setCnTransportqOutUid(19L);
+    when(transformerServiceMock.transform(any())).thenReturn(messageAfterStdChecker);
+
+    CnTransportqOutMessage msg = new CnTransportqOutMessage();
+    EnvelopePayload payload = new EnvelopePayload();
+    CnTransportqOutValue after = new CnTransportqOutValue();
+    payload.setAfter(after);
+    msg.setPayload(payload);
+
+    consumer.handleMessage(new Gson().toJson(msg));
+
+    verify(updateServiceMock).updateRecordStatus(eq(19L), eq("STD_PROCESSING"));
+  }
+
+  @Test
+  public void handleMessage_nonStdMessage() {
+    CaseNotificationConfig config = new CaseNotificationConfig();
+    config.setConfigApplied(true);
+    when(caseNotificationConfigRepositoryMock.findNonStdConfig()).thenReturn(config);
+
+    MessageAfterStdChecker messageAfterStdChecker = new MessageAfterStdChecker();
+    messageAfterStdChecker.setStdMessageDetected(false);
+    messageAfterStdChecker.setCnTransportqOutUid(19L);
+    when(transformerServiceMock.transform(any(CnTransportqOutValue.class)))
+        .thenReturn(messageAfterStdChecker);
+
+    CnTransportqOutMessage msg = new CnTransportqOutMessage();
+    EnvelopePayload payload = new EnvelopePayload();
+    CnTransportqOutValue after = new CnTransportqOutValue();
+    payload.setAfter(after);
+    msg.setPayload(payload);
+
+    consumer.handleMessage(new Gson().toJson(msg));
+
+    verify(updateServiceMock).updateRecordStatus(eq(19L), eq("NON_STD_PROCESSING"));
+  }
+
+  @Test
+  public void processEvent_std()
+      throws IgnorableException,
+          NonRetryableException,
+          NonStdProcessorServiceException,
+          StdProcessorServiceException,
+          NonStdBatchProcessorServiceException {
+    MessageAfterStdChecker message = new MessageAfterStdChecker();
+    message.setStdMessageDetected(true);
+
+    when(configurationServiceMock.checkConfigurationAvailable()).thenReturn(true);
+
+    consumer.processEvent(message);
+
+    verify(xmlServiceMock).mappingXmlStringToObject(eq(message));
+    verify(nonStdServiceMock, times(0))
+        .nonStdProcessor(any(MessageAfterStdChecker.class), any(Boolean.class));
+  }
+
+  @Test
+  public void processEvent_nonStd()
+      throws IgnorableException,
+          NonRetryableException,
+          NonStdProcessorServiceException,
+          StdProcessorServiceException,
+          NonStdBatchProcessorServiceException {
+    MessageAfterStdChecker message = new MessageAfterStdChecker();
+    message.setStdMessageDetected(false);
+
+    when(configurationServiceMock.checkConfigurationAvailable()).thenReturn(true);
+    when(configurationServiceMock.checkHl7ValidationApplied()).thenReturn(true);
+
+    consumer.processEvent(message);
+
+    verify(nonStdServiceMock).nonStdProcessor(eq(message), eq(true));
+    verify(xmlServiceMock, times(0)).mappingXmlStringToObject(any(MessageAfterStdChecker.class));
+  }
+}

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/cntransportqout/StdCheckerTransformerServiceTests.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/cntransportqout/StdCheckerTransformerServiceTests.java
@@ -1,0 +1,108 @@
+package gov.cdc.casenotificationservice.service.cntransportqout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import gov.cdc.casenotificationservice.model.CnTransportqOutValue;
+import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class StdCheckerTransformerServiceTests {
+
+  private StdCheckerTransformerService transformerService;
+
+  @BeforeEach
+  void setUp() {
+    transformerService = new StdCheckerTransformerService();
+  }
+
+  @Test
+  void testTransform_NullInput() {
+    MessageAfterStdChecker result = transformerService.transform(null);
+    assertNull(result);
+  }
+
+  @Test
+  void testTransform_RecordStatusCdNotUnprocessed() {
+    var input = new CnTransportqOutValue();
+    input.setRecord_status_cd("PROCESSED");
+
+    MessageAfterStdChecker result = transformerService.transform(input);
+    assertNull(result);
+  }
+
+  @Test
+  void testTransform_NullPayload() {
+    var input = new CnTransportqOutValue();
+    input.setRecord_status_cd("UNPROCESSED");
+    input.setMessage_payload(null);
+
+    MessageAfterStdChecker result = transformerService.transform(input);
+    assertNull(result);
+  }
+
+  @Test
+  void testTransform_STDTrigger_NETSS_MESSAGE_ONLY() {
+    ReflectionTestUtils.setField(
+        transformerService, "netssMessageOnlyConfig", "NETSS_MESSAGE_ONLY");
+
+    var input = new CnTransportqOutValue();
+    input.setRecord_status_cd("UNPROCESSED");
+    input.setMessage_payload("<stringData>STD_MMG_V1.0</stringData>");
+    input.setCn_transportq_out_uid(123L);
+    input.setNotification_local_id("NID123");
+    input.setPublic_health_case_local_id("PHCID123");
+    input.setReport_status_cd("REPORT123");
+
+    MessageAfterStdChecker result = transformerService.transform(input);
+
+    assertNotNull(result);
+    assertTrue(result.isStdMessageDetected());
+    assertEquals("NETSS_MESSAGE_ONLY", result.getNetssMessageOnly());
+    assertEquals("NID123", result.getNotificationLocalId());
+    assertEquals("PHCID123", result.getPublicHealthCaseLocalId());
+    assertEquals("REPORT123", result.getReportStatusCd());
+  }
+
+  @Test
+  void testTransform_STDTrigger_BOTH() {
+    ReflectionTestUtils.setField(transformerService, "netssMessageOnlyConfig", "BOTH");
+
+    var input = new CnTransportqOutValue();
+    input.setRecord_status_cd("UNPROCESSED");
+    input.setMessage_payload("<stringData>STD_MMG_V1.0</stringData>");
+
+    MessageAfterStdChecker result = transformerService.transform(input);
+
+    assertNotNull(result);
+    assertEquals("BOTH", result.getNetssMessageOnly());
+  }
+
+  @Test
+  void testTransform_STDTrigger_DefaultQueued() {
+    ReflectionTestUtils.setField(transformerService, "netssMessageOnlyConfig", "UNKNOWN");
+
+    var input = new CnTransportqOutValue();
+    input.setRecord_status_cd("UNPROCESSED");
+    input.setMessage_payload("<stringData>STD_MMG_V1.0</stringData>");
+
+    MessageAfterStdChecker result = transformerService.transform(input);
+
+    assertNotNull(result);
+    assertEquals("queued", result.getNetssMessageOnly());
+  }
+
+  @Test
+  void testTransform_ReplacesSpecialCharacters() {
+    ReflectionTestUtils.setField(
+        transformerService, "netssMessageOnlyConfig", "NETSS_MESSAGE_ONLY");
+    var input = new CnTransportqOutValue();
+    input.setRecord_status_cd("UNPROCESSED");
+    input.setMessage_payload("Don't use â€™ or ' characters<stringData>STD_MMG_V1.0</stringData>");
+    MessageAfterStdChecker result = transformerService.transform(input);
+    assertNotNull(result);
+  }
+}

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/cntransportqout/UpdateServiceTests.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/cntransportqout/UpdateServiceTests.java
@@ -1,0 +1,49 @@
+package gov.cdc.casenotificationservice.service.cntransportqout;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class UpdateServiceTests {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  @InjectMocks private UpdateService service;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void testUpdateRecordStatus_Success() {
+    long uid = 100L;
+    String status = "COMPLETED";
+
+    when(jdbcTemplate.update(anyString(), eq(status), eq(uid))).thenReturn(1);
+
+    service.updateRecordStatus(uid, status);
+
+    verify(jdbcTemplate).update(anyString(), eq(status), eq(uid));
+  }
+
+  @Test
+  void testUpdateRecordStatus_NoRowsAffected() {
+    long uid = 101L;
+    String status = "FAILED";
+
+    when(jdbcTemplate.update(anyString(), eq(status), eq(uid))).thenReturn(0);
+
+    service.updateRecordStatus(uid, status);
+
+    verify(jdbcTemplate).update(anyString(), eq(status), eq(uid));
+  }
+}

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/common/DltServiceTest.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/common/DltServiceTest.java
@@ -1,9 +1,15 @@
 package gov.cdc.casenotificationservice.service.common;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+import com.google.gson.Gson;
 import gov.cdc.casenotificationservice.exception.DltServiceException;
 import gov.cdc.casenotificationservice.kafka.producer.CaseNotificationProducer;
+import gov.cdc.casenotificationservice.model.CnTransportqOutMessage;
+import gov.cdc.casenotificationservice.model.CnTransportqOutValue;
+import gov.cdc.casenotificationservice.model.EnvelopePayload;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationDltRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationDlt;
 import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
@@ -12,6 +18,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -31,22 +38,71 @@ public class DltServiceTest {
 
   @InjectMocks private DltService dltService;
 
+  private AutoCloseable mockAutoClosable;
+
   private final String jsonPayload = "{\"cnTransportqOutUid\":12345}";
   private final String uuid = UUID.randomUUID().toString();
 
   @BeforeEach
   public void setUp() {
-    MockitoAnnotations.openMocks(this);
+    mockAutoClosable = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockAutoClosable.close();
+  }
+
+  @Test
+  public void creatingDlt_badInput() {
+    // throws with null
+    assertThrows(
+        RuntimeException.class,
+        () -> dltService.creatingDlt(null, "topic", "stacktrace", "origin"));
+
+    Gson gson = new Gson();
+    CnTransportqOutMessage cnTransportqOutMessage = new CnTransportqOutMessage();
+
+    // throws with null payload
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            dltService.creatingDlt(
+                gson.toJson(cnTransportqOutMessage), "topic", "stacktrace", "origin"));
+
+    EnvelopePayload envelopePayload = new EnvelopePayload();
+    cnTransportqOutMessage.setPayload(envelopePayload);
+
+    // throws with incomplete payload
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            dltService.creatingDlt(
+                gson.toJson(cnTransportqOutMessage), "topic", "stacktrace", "origin"));
+
+    envelopePayload.setAfter(new CnTransportqOutValue());
+
+    // does not throw with complete payload
+    assertDoesNotThrow(
+        () ->
+            dltService.creatingDlt(
+                gson.toJson(cnTransportqOutMessage), "topic", "stacktrace", "origin"));
   }
 
   @Test
   public void testCreatingDlt() {
+    CnTransportqOutMessage cnTransportqOutMessage = new CnTransportqOutMessage();
+    EnvelopePayload envelopePayload = new EnvelopePayload();
+    envelopePayload.setAfter(new CnTransportqOutValue());
+    cnTransportqOutMessage.setPayload(envelopePayload);
+    String json = new Gson().toJson(cnTransportqOutMessage);
+
     CNTransportqOut mockTransport = new CNTransportqOut();
     mockTransport.setMessagePayload("mock-payload");
 
     when(cnTransportqOutRepository.findTopByRecordUid(12345L)).thenReturn(mockTransport);
 
-    dltService.creatingDlt(jsonPayload, "non-std-topic", "stacktrace", "root");
+    dltService.creatingDlt(json, "non-std-topic", "stacktrace", "root");
 
     verify(dltRepository, times(1)).save(any(CaseNotificationDlt.class));
   }

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/common/DltServiceTest.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/common/DltServiceTest.java
@@ -6,7 +6,7 @@ import gov.cdc.casenotificationservice.exception.DltServiceException;
 import gov.cdc.casenotificationservice.kafka.producer.CaseNotificationProducer;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationDltRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationDlt;
-import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import java.sql.Timestamp;
 import java.util.List;
@@ -25,7 +25,7 @@ public class DltServiceTest {
 
   @Mock private CaseNotificationDltRepository dltRepository;
 
-  @Mock private CNTransportqOutRepository cnTransportqOutRepository;
+  @Mock private CNTransportQOutRepository cnTransportqOutRepository;
 
   @Mock private CaseNotificationProducer producer;
 

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/common/DltServiceTest.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/common/DltServiceTest.java
@@ -6,7 +6,7 @@ import gov.cdc.casenotificationservice.exception.DltServiceException;
 import gov.cdc.casenotificationservice.kafka.producer.CaseNotificationProducer;
 import gov.cdc.casenotificationservice.repository.msg.CaseNotificationDltRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationDlt;
-import gov.cdc.casenotificationservice.repository.odse.CNTraportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
 import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import java.sql.Timestamp;
 import java.util.List;
@@ -25,7 +25,7 @@ public class DltServiceTest {
 
   @Mock private CaseNotificationDltRepository dltRepository;
 
-  @Mock private CNTraportqOutRepository cnTraportqOutRepository;
+  @Mock private CNTransportqOutRepository cnTransportqOutRepository;
 
   @Mock private CaseNotificationProducer producer;
 
@@ -44,7 +44,7 @@ public class DltServiceTest {
     CNTransportqOut mockTransport = new CNTransportqOut();
     mockTransport.setMessagePayload("mock-payload");
 
-    when(cnTraportqOutRepository.findTopByRecordUid(12345L)).thenReturn(mockTransport);
+    when(cnTransportqOutRepository.findTopByRecordUid(12345L)).thenReturn(mockTransport);
 
     dltService.creatingDlt(jsonPayload, "non-std-topic", "stacktrace", "root");
 
@@ -100,7 +100,7 @@ public class DltServiceTest {
     CNTransportqOut mockTransport = new CNTransportqOut();
     mockTransport.setMessagePayload("mock-payload");
     mockTransport.setCnTransportqOutUid(123L);
-    when(cnTraportqOutRepository.findTopByRecordUid(123L)).thenReturn(mockTransport);
+    when(cnTransportqOutRepository.findTopByRecordUid(123L)).thenReturn(mockTransport);
     dltService.reprocessingCaseNotification(jsonPayload, uuid);
 
     verify(dltRepository).save(any(CaseNotificationDlt.class));

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/nonstd/NonStdServiceTest.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/nonstd/NonStdServiceTest.java
@@ -8,7 +8,7 @@ import gov.cdc.casenotificationservice.repository.msg.CaseNotificationConfigRepo
 import gov.cdc.casenotificationservice.repository.msg.TransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationConfig;
 import gov.cdc.casenotificationservice.repository.msg.model.TransportQOut;
-import gov.cdc.casenotificationservice.repository.odse.CNTraportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
 import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.INonStdBatchService;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.IPHINMSService;
@@ -29,7 +29,7 @@ class NonStdServiceTest {
 
   @Mock private TransportQOutRepository transportQOutRepository;
 
-  @Mock private CNTraportqOutRepository cnTraportqOutRepository;
+  @Mock private CNTransportqOutRepository cnTransportqOutRepository;
 
   @Mock private CaseNotificationConfigRepository caseNotificationConfigRepository;
 
@@ -60,8 +60,8 @@ class NonStdServiceTest {
     when(hl7MessageBuilder.buildHl7Message(mockTransport.getMessagePayload(), true))
         .thenReturn("TEST");
 
-    when(caseNotificationConfigRepository.findNonStdConfig()).thenReturn(config);
-    when(cnTraportqOutRepository.findTopByRecordUid(123L)).thenReturn(mockTransport);
+    when(caseNotificationConfigRepository.findAppliedNonStdConfig()).thenReturn(config);
+    when(cnTransportqOutRepository.findTopByRecordUid(123L)).thenReturn(mockTransport);
     when(phinmsService.gettingPHIMNSProperties(any(), any(), any())).thenReturn(props);
     when(batchService.isBatchConditionApplied(props, config)).thenReturn(true);
 
@@ -89,15 +89,15 @@ class NonStdServiceTest {
 
     when(hl7MessageBuilder.buildHl7Message(mockTransport.getMessagePayload(), true))
         .thenReturn("TEST");
-    when(caseNotificationConfigRepository.findNonStdConfig()).thenReturn(config);
-    when(cnTraportqOutRepository.findTopByRecordUid(124L)).thenReturn(mockTransport);
+    when(caseNotificationConfigRepository.findAppliedNonStdConfig()).thenReturn(config);
+    when(cnTransportqOutRepository.findTopByRecordUid(124L)).thenReturn(mockTransport);
     when(phinmsService.gettingPHIMNSProperties(any(), any(), any())).thenReturn(props);
     when(batchService.isBatchConditionApplied(props, config)).thenReturn(false);
 
     nonStdService.nonStdProcessor(checker, true);
 
     verify(transportQOutRepository).save(any(TransportQOut.class));
-    verify(cnTraportqOutRepository).updateStatusToQueued(null);
+    verify(cnTransportqOutRepository).updateStatusToQueued(null);
   }
 
   @Test
@@ -110,6 +110,6 @@ class NonStdServiceTest {
     nonStdService.releaseHoldQueueAndProcessBatchNonStd();
 
     verify(transportQOutRepository).save(any(TransportQOut.class));
-    verify(cnTraportqOutRepository).updateStatusToQueued(null);
+    verify(cnTransportqOutRepository).updateStatusToQueued(null);
   }
 }

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/nonstd/NonStdServiceTest.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/nonstd/NonStdServiceTest.java
@@ -8,7 +8,7 @@ import gov.cdc.casenotificationservice.repository.msg.CaseNotificationConfigRepo
 import gov.cdc.casenotificationservice.repository.msg.TransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.CaseNotificationConfig;
 import gov.cdc.casenotificationservice.repository.msg.model.TransportQOut;
-import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.INonStdBatchService;
 import gov.cdc.casenotificationservice.service.nonstd.interfaces.IPHINMSService;
@@ -29,7 +29,7 @@ class NonStdServiceTest {
 
   @Mock private TransportQOutRepository transportQOutRepository;
 
-  @Mock private CNTransportqOutRepository cnTransportqOutRepository;
+  @Mock private CNTransportQOutRepository cnTransportqOutRepository;
 
   @Mock private CaseNotificationConfigRepository caseNotificationConfigRepository;
 

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/std/XmlServiceTest.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/std/XmlServiceTest.java
@@ -8,7 +8,7 @@ import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
 import gov.cdc.casenotificationservice.model.Netss;
 import gov.cdc.casenotificationservice.repository.msg.NetssTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.NetssTransportQOut;
-import gov.cdc.casenotificationservice.repository.odse.CNTraportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
 import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import gov.cdc.casenotificationservice.service.std.interfaces.IStdMapperService;
 import java.io.IOException;
@@ -22,18 +22,18 @@ import org.mockito.ArgumentCaptor;
 
 class XmlServiceTest {
 
-  private CNTraportqOutRepository cnTraportqOutRepository;
+  private CNTransportqOutRepository cnTransportqOutRepository;
   private IStdMapperService stdMapperService;
   private NetssTransportQOutRepository netssTransportQOutRepository;
   private XmlService xmlService;
 
   @BeforeEach
   void setUp() {
-    cnTraportqOutRepository = mock(CNTraportqOutRepository.class);
+    cnTransportqOutRepository = mock(CNTransportqOutRepository.class);
     stdMapperService = mock(IStdMapperService.class);
     netssTransportQOutRepository = mock(NetssTransportQOutRepository.class);
     xmlService =
-        new XmlService(cnTraportqOutRepository, stdMapperService, netssTransportQOutRepository);
+        new XmlService(cnTransportqOutRepository, stdMapperService, netssTransportQOutRepository);
   }
 
   @Test
@@ -46,7 +46,7 @@ class XmlServiceTest {
     cnTransportqOut.setMessagePayload(readFileFromResources("std_test.txt"));
     cnTransportqOut.setRecordStatusCd("A");
 
-    when(cnTraportqOutRepository.findTopByRecordUid(123L)).thenReturn(cnTransportqOut);
+    when(cnTransportqOutRepository.findTopByRecordUid(123L)).thenReturn(cnTransportqOut);
 
     Netss mappedNetss = new Netss();
     mappedNetss.setCaseReportId("CASE123");
@@ -79,7 +79,7 @@ class XmlServiceTest {
     cnTransportqOut.setMessagePayload(readFileFromResources("std_test.txt"));
     cnTransportqOut.setRecordStatusCd("X");
 
-    when(cnTraportqOutRepository.findTopByRecordUid(456L)).thenReturn(cnTransportqOut);
+    when(cnTransportqOutRepository.findTopByRecordUid(456L)).thenReturn(cnTransportqOut);
 
     Netss mappedNetss = new Netss();
     mappedNetss.setCaseReportId("CASE456");

--- a/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/std/XmlServiceTest.java
+++ b/case-notification-service/src/test/java/gov/cdc/casenotificationservice/service/std/XmlServiceTest.java
@@ -8,7 +8,7 @@ import gov.cdc.casenotificationservice.model.MessageAfterStdChecker;
 import gov.cdc.casenotificationservice.model.Netss;
 import gov.cdc.casenotificationservice.repository.msg.NetssTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.msg.model.NetssTransportQOut;
-import gov.cdc.casenotificationservice.repository.odse.CNTransportqOutRepository;
+import gov.cdc.casenotificationservice.repository.odse.CNTransportQOutRepository;
 import gov.cdc.casenotificationservice.repository.odse.model.CNTransportqOut;
 import gov.cdc.casenotificationservice.service.std.interfaces.IStdMapperService;
 import java.io.IOException;
@@ -22,14 +22,14 @@ import org.mockito.ArgumentCaptor;
 
 class XmlServiceTest {
 
-  private CNTransportqOutRepository cnTransportqOutRepository;
+  private CNTransportQOutRepository cnTransportqOutRepository;
   private IStdMapperService stdMapperService;
   private NetssTransportQOutRepository netssTransportQOutRepository;
   private XmlService xmlService;
 
   @BeforeEach
   void setUp() {
-    cnTransportqOutRepository = mock(CNTransportqOutRepository.class);
+    cnTransportqOutRepository = mock(CNTransportQOutRepository.class);
     stdMapperService = mock(IStdMapperService.class);
     netssTransportQOutRepository = mock(NetssTransportQOutRepository.class);
     xmlService =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,17 +41,3 @@ services:
       NND_DE_SECRET: ${NND_DE_SECRET}
     depends_on:
       - kafka
-
-  data-extraction-service:
-    build:
-      context: .
-      dockerfile: data-extraction-service/Dockerfile
-    ports:
-      - "8090:8090"
-    environment:
-      NBS_DBSERVER: host.docker.internal:1433
-      NBS_DBUSER: ${NBS_DBUSER}
-      NBS_DBPASSWORD: ${NBS_DBPASSWORD}
-      KAFKA_BOOTSTRAP_SERVER: kafka:9092
-    depends_on:
-      - kafka


### PR DESCRIPTION
## Links
- [JIRA Ticket](https://cdc-nbs.atlassian.net/browse/CTHLU-69)
- [Google Sheet tracking all copied files](https://docs.google.com/spreadsheets/d/1ulsd1yX73N3Amp5Eu3pZypEfdXu8kWEXklQwVII1yBI/edit?gid=0#gid=0)

## Description
This is the first PR for the consolidation of the `data-extraction-service` into the `case-notification-service`.  It copies over all code and config for `data-extraction-service` while leaving the existing code in-tact (this will be removed in a later ticket).